### PR TITLE
Add Oculus Quest VR stub

### DIFF
--- a/jp2_pc/CMakeLists.txt
+++ b/jp2_pc/CMakeLists.txt
@@ -31,6 +31,12 @@ set(CMAKE_CONFIGURATION_TYPES Debug Release Final CACHE STRING INTERNAL FORCE)
 
 include(cmake/CMakeCommon.cmake)
 
+# Optional Oculus Quest support
+option(ENABLE_OCULUS_QUEST_SUPPORT "Build with Oculus Quest VR support" OFF)
+if(ENABLE_OCULUS_QUEST_SUPPORT)
+    add_subdirectory(cmake/VR)
+endif()
+
 add_subdirectory(cmake/AI)
 add_subdirectory(cmake/AITest)
 add_subdirectory(cmake/Audio)

--- a/jp2_pc/Source/Lib/VR/README.md
+++ b/jp2_pc/Source/Lib/VR/README.md
@@ -1,0 +1,5 @@
+# VR Stub
+
+This directory contains initial placeholder code for Oculus Quest support. The
+implementation currently logs basic initialization and shutdown messages. It
+aims to serve as a starting point for a full VR port.

--- a/jp2_pc/Source/Lib/VR/VR.cpp
+++ b/jp2_pc/Source/Lib/VR/VR.cpp
@@ -1,0 +1,25 @@
+#include "VR.hpp"
+#include <cstdio>
+
+namespace VR {
+
+bool Initialize() {
+    // Placeholder for Oculus Quest initialization
+    std::printf("VR Initialize stub\n");
+    return true;
+}
+
+void Shutdown() {
+    // Placeholder cleanup
+    std::printf("VR Shutdown stub\n");
+}
+
+void BeginFrame() {
+    // Placeholder per-frame begin
+}
+
+void EndFrame() {
+    // Placeholder per-frame end
+}
+
+} // namespace VR

--- a/jp2_pc/Source/Lib/VR/VR.hpp
+++ b/jp2_pc/Source/Lib/VR/VR.hpp
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Oculus Quest VR stub interface.
+ *******************************************************************************/
+#ifndef HEADER_LIB_VR_VR_HPP
+#define HEADER_LIB_VR_VR_HPP
+
+namespace VR {
+
+bool Initialize();
+void Shutdown();
+void BeginFrame();
+void EndFrame();
+
+} // namespace VR
+
+#endif // HEADER_LIB_VR_VR_HPP

--- a/jp2_pc/cmake/VR/CMakeLists.txt
+++ b/jp2_pc/cmake/VR/CMakeLists.txt
@@ -1,0 +1,20 @@
+project(VR)
+
+list(APPEND VR_Inc
+    ${CMAKE_SOURCE_DIR}/Source/Lib/VR/VR.hpp
+)
+
+list(APPEND VR_Src
+    ${CMAKE_SOURCE_DIR}/Source/Lib/VR/VR.cpp
+)
+
+include_directories(
+    ${CMAKE_SOURCE_DIR}/Source
+    ${CMAKE_SOURCE_DIR}/Source/gblinc
+)
+
+add_common_options()
+
+add_library(${PROJECT_NAME} STATIC ${VR_Inc} ${VR_Src})
+
+set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Lib/Game)

--- a/jp2_pc/cmake/trespass/CMakeLists.txt
+++ b/jp2_pc/cmake/trespass/CMakeLists.txt
@@ -92,6 +92,10 @@ target_link_libraries(${PROJECT_NAME}
     ${CMAKE_SOURCE_DIR}/lib/smacker/SMACKW32.LIB
 )
 
+if(ENABLE_OCULUS_QUEST_SUPPORT)
+    target_link_libraries(${PROJECT_NAME} VR)
+endif()
+
 target_link_options(${PROJECT_NAME} PUBLIC "/SAFESEH:NO") #Needed only for old Smacker lib, remove when it gets replaced
 
 target_precompile_headers(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/Source/trespass/precomp.h)


### PR DESCRIPTION
## Summary
- add initial Oculus Quest support option
- link VR library when enabled
- stub out VR initialization in new `VR` library

## Testing
- `cmake --version`
- `cmake -S jp2_pc -B build` *(fails: gtest missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ff313b69483318ee406617a05a174