### PR TITLE
Add initial Android VR stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ A git-based fork of the Jurassic Park: Trespasser source code.
 
 Sanglard, F. (2014). "Solution Overview" [list] & "Production Pipeline" [image].  
 Available at: http://fabiensanglard.net/trespasser [Accessed 17 Oct. 2018].
+
+## Oculus Quest Support
+A minimal VR stub can be enabled via `ENABLE_OCULUS_QUEST_SUPPORT` when configuring with CMake. This is the starting point for an Android/Quest port.

--- a/jp2_pc/Source/Lib/VR/README.md
+++ b/jp2_pc/Source/Lib/VR/README.md
@@ -1,5 +1,7 @@
 # VR Stub
 
-This directory contains initial placeholder code for Oculus Quest support. The
-implementation currently logs basic initialization and shutdown messages. It
-aims to serve as a starting point for a full VR port.
+This directory contains placeholder code for Oculus Quest support. The implementation logs initialization and shutdown messages.
+
+A basic Android-specific implementation is provided in `android/VR_Android.cpp`. It uses `android/log.h` to output messages when running on an Android-based headset such as the Oculus Quest.
+
+To build for Android enable the `ENABLE_OCULUS_QUEST_SUPPORT` option and use an Android toolchain with CMake. The library will compile the Android stub automatically when the `ANDROID` variable is set.

--- a/jp2_pc/Source/Lib/VR/android/VR_Android.cpp
+++ b/jp2_pc/Source/Lib/VR/android/VR_Android.cpp
@@ -1,0 +1,24 @@
+#include "../VR.hpp"
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
+
+namespace VR {
+
+bool Initialize() {
+#ifdef __ANDROID__
+    __android_log_print(ANDROID_LOG_INFO, "Trespasser", "VR Android Initialize stub");
+#endif
+    return true;
+}
+
+void Shutdown() {
+#ifdef __ANDROID__
+    __android_log_print(ANDROID_LOG_INFO, "Trespasser", "VR Android Shutdown stub");
+#endif
+}
+
+void BeginFrame() {}
+void EndFrame() {}
+
+} // namespace VR

--- a/jp2_pc/cmake/VR/CMakeLists.txt
+++ b/jp2_pc/cmake/VR/CMakeLists.txt
@@ -8,6 +8,12 @@ list(APPEND VR_Src
     ${CMAKE_SOURCE_DIR}/Source/Lib/VR/VR.cpp
 )
 
+if(ANDROID)
+    list(APPEND VR_Src
+        ${CMAKE_SOURCE_DIR}/Source/Lib/VR/android/VR_Android.cpp
+    )
+endif()
+
 include_directories(
     ${CMAKE_SOURCE_DIR}/Source
     ${CMAKE_SOURCE_DIR}/Source/gblinc


### PR DESCRIPTION
## Summary
- add a small Oculus Quest/Android VR stub
- compile VR library with Android file when building for Android
- document VR build steps and new option in README

## Testing
- `cmake -S jp2_pc -B build` *(fails: Common.hpp missing)*
- `cmake --build build -j4` *(fails: Build errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9b8c6e0833197e1d26a80846f11