### PR TITLE
Add placeholder controller input APIs

### DIFF
--- a/jp2_pc/Source/Lib/Control/Control.cpp
+++ b/jp2_pc/Source/Lib/Control/Control.cpp
@@ -149,16 +149,20 @@ void CInputDeemone::Process(const CMessageStep& msg_step)
 		SInput tin;
 
 		// which control method are we using.....
-		switch (ecm_Control)
-		{
-		case ecm_DefaultControls:
-			tin=inp_Input.tinReadDefaultControls();
-			break;
+                switch (ecm_Control)
+                {
+                case ecm_DefaultControls:
+                        tin=inp_Input.tinReadDefaultControls();
+                        break;
 
-		case ecm_Joystick:
-			tin=inp_Input.tinReadStandardJoystickControls();
-			break;
-		}
+                case ecm_Joystick:
+                        tin=inp_Input.tinReadStandardJoystickControls();
+                        break;
+
+                case ecm_GameController:
+                        tin=inp_Input.tinReadGameController();
+                        break;
+                }
 
 		tin.fElapsedTime = msg_step.sStep;
 
@@ -871,8 +875,28 @@ bool bReadJoystickSimple(float& rf_x, float& rf_y, float& rf_z, bool& rb_trigger
 	rf_y -= 1.0f;
 	rf_z -= 1.0f;
 	rb_trigger = ji.dwButtons & 1;
-	rb_thumb   = ji.dwButtons & 2;
+        rb_thumb   = ji.dwButtons & 2;
 
-	return true;
+        return true;
+}
+
+//******************************************************************************
+//
+// Placeholder for modern controller input using SDL or platform APIs.
+// Always returns no input when controller support is unavailable.
+//
+SInput& CInput::tinReadGameController()
+{
+        // Clear all control values.
+        tin_Input.u4ButtonState = 0;
+        tin_Input.u4ButtonHit = 0;
+        tin_Input.v2Move = CVector2<>(0.0f, 0.0f);
+        tin_Input.v2Rotate = CVector2<>(0.0f, 0.0f);
+
+#ifdef USE_SDL_CONTROLLER
+        // SDL2 controller query would go here
+#endif
+
+        return tin_Input;
 }
 

--- a/jp2_pc/Source/Lib/Control/Control.hpp
+++ b/jp2_pc/Source/Lib/Control/Control.hpp
@@ -86,8 +86,9 @@ typedef void* myHANDLE;
 enum EControlMethod
 // prefix: ecm
 {
-	ecm_DefaultControls,
-	ecm_Joystick
+        ecm_DefaultControls,
+        ecm_Joystick,
+        ecm_GameController
 };
 
 
@@ -181,8 +182,9 @@ public:
 
 	// functions to return the controls in the standard form of a Tinput struct
 	// these functions may use win32 or DirectInput to do their work.
-	SInput& tinReadDefaultControls();
-	SInput& tinReadStandardJoystickControls();
+        SInput& tinReadDefaultControls();
+        SInput& tinReadStandardJoystickControls();
+        SInput& tinReadGameController();
 
 private:
 

--- a/jp2_pc/Source/Lib/VR/README.md
+++ b/jp2_pc/Source/Lib/VR/README.md
@@ -15,3 +15,8 @@ environment will not be rendered. The environment intensity and orientation can
 be adjusted at runtime via `Renderer::SetEnvironmentIntensity()` and
 `Renderer::SetEnvironmentRotation()` whenever the renderer is available.
 
+### Controller Input
+`VR::GetControllerInput()` returns an `SInput` struct describing the state of any
+connected VR controllers. The current implementation is a stub which will return
+zeroed values when no VR controller integration is available.
+

--- a/jp2_pc/Source/Lib/VR/VR.cpp
+++ b/jp2_pc/Source/Lib/VR/VR.cpp
@@ -53,4 +53,12 @@ void EndFrame() {
 #endif
 }
 
+SInput GetControllerInput() {
+  SInput input{};
+#ifdef ENABLE_OCULUS_QUEST_SUPPORT
+  // Integrate actual VR controller input here when available
+#endif
+  return input;
+}
+
 } // namespace VR

--- a/jp2_pc/Source/Lib/VR/VR.hpp
+++ b/jp2_pc/Source/Lib/VR/VR.hpp
@@ -8,6 +8,7 @@
 #include "Lib/Renderer/EnvironmentModern.hpp"
 #include <GLES3/gl3.h>
 #endif
+#include "Lib/Control/Control.hpp"
 
 namespace VR {
 
@@ -17,6 +18,9 @@ bool Initialize(const char *envCubemapFolder = nullptr);
 void Shutdown();
 void BeginFrame();
 void EndFrame();
+
+// Retrieve input from VR controllers when available.
+SInput GetControllerInput();
 
 } // namespace VR
 


### PR DESCRIPTION
## Summary
- add a `GameController` control method
- provide stub implementation of `tinReadGameController`
- expose `VR::GetControllerInput` and document the feature

## Testing
- `cmake -S jp2_pc -B build` *(fails: Parse error. Expected a newline, got identifier)*

------
https://chatgpt.com/codex/tasks/task_e_6841417b10b88331ab7977344871103b