### PR TITLE
Fix include paths for case-sensitive build

### DIFF
--- a/Lib/GblInc/common.hpp
+++ b/Lib/GblInc/common.hpp
@@ -69,11 +69,11 @@
 #ifndef HEADER_GBLINC_COMMON_HPP
 #define HEADER_GBLINC_COMMON_HPP
 
-#include "GblInc/Warnings.hpp"
+#include "gblinc/Warnings.hpp"
 #include <new>
 #include <stddef.h>
 
-#include "GblInc/BuildVer.hpp"
+#include "gblinc/BuildVer.hpp"
 
 #include "Lib/Std/Array.hpp"
 #include "Lib/Std/InitSys.hpp"

--- a/jp2_pc/CMakeLists.txt
+++ b/jp2_pc/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CMAKE_CONFIGURATION_TYPES Debug Release Final CACHE STRING INTERNAL FORCE)
 include(cmake/CMakeCommon.cmake)
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/../Lib/GblInc
+    ${CMAKE_SOURCE_DIR}/../Lib           # for GblInc headers
     ${CMAKE_SOURCE_DIR}/Source/gblinc
 )
 

--- a/jp2_pc/Source/Lib/Audio/SoundDefs.hpp
+++ b/jp2_pc/Source/Lib/Audio/SoundDefs.hpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************
  *
- * Copyright © DreamWorks Interactive. 1997
+ * Copyright Â© DreamWorks Interactive. 1997
  *
  * Contents:
  *	Sound definitions.
@@ -91,7 +91,7 @@
 #ifndef HEADER_LIB_AUDIO_DEFS_HPP
 #define HEADER_LIB_AUDIO_DEFS_HPP
 
-#include "Lib/std/utypes.hpp"
+#include "Lib/Std/UTypes.hpp"
 
 
 //**********************************************************************************************

--- a/jp2_pc/Source/Lib/Audio/SoundTypes.hpp
+++ b/jp2_pc/Source/Lib/Audio/SoundTypes.hpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************
  *
- * Copyright © DreamWorks Interactive. 1997
+ * Copyright Â© DreamWorks Interactive. 1997
  *
  * Contents:
  *	Standard header file for sound library, this is required so that the audio library
@@ -34,8 +34,12 @@
 #ifndef _H_SOUNDTYPESHEADER
 #define _H_SOUNDTYPESHEADER
 
-#include "windows.h"
-#include "crtdbg.h"
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#ifdef _WIN32
+#include <crtdbg.h>
+#endif
 #include "Lib/Std/UTypes.hpp"
 #include "Lib/Std/UAssert.hpp"
 

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgAudio.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgAudio.hpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************
  *
- * Copyright © DreamWorks Interactive. 1997
+ * Copyright Â© DreamWorks Interactive. 1997
  *
  * Contents:
  *		Audio specific messages.
@@ -58,7 +58,7 @@
 #include "Lib/EntityDBase/Message.hpp"
 #include "Lib/EntityDBase/MessageTypes/RegisteredMsg.hpp"
 #include "Lib/EntityDBase/Entity.hpp"
-#include "lib/audio/SoundDefs.hpp"
+#include "Lib/Audio/SoundDefs.hpp"
 
 
 //*********************************************************************************************

--- a/jp2_pc/Source/Test/AudioTest.cpp
+++ b/jp2_pc/Source/Test/AudioTest.cpp
@@ -8,7 +8,7 @@
 
 #include <yvals.h>
 
-#include "lib/audio/audio.hpp"
+#include "Lib/Audio/Audio.hpp"
 
 #include "MainFrm.h"
 #include "AudioTestDoc.h"

--- a/jp2_pc/Source/Test/AudioTestDoc.cpp
+++ b/jp2_pc/Source/Test/AudioTestDoc.cpp
@@ -8,7 +8,7 @@
 
 #include <yvals.h>
 
-#include "lib/audio/audio.hpp"
+#include "Lib/Audio/Audio.hpp"
 #include "Lib/Transform/Vector.hpp"
 #include "AudioTestDoc.h"
 #include "AttribDlg.h"

--- a/jp2_pc/Source/Test/AudioTestView.cpp
+++ b/jp2_pc/Source/Test/AudioTestView.cpp
@@ -11,7 +11,7 @@
 
 #include <yvals.h>
 
-#include "lib/audio/audio.hpp"
+#include "Lib/Audio/Audio.hpp"
 #include "Lib/Transform/Vector.hpp"
 
 #include "AudioTestDoc.h"


### PR DESCRIPTION
## Summary
- adjust global include directory to correctly reference `Lib/GblInc`
- fix case for header paths in `common.hpp`
- guard Windows-specific headers
- correct audio test includes

## Testing
- `cmake -S jp2_pc -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build` *(fails: dsound.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684149b9d5b88331a8630393e77353eb