### PR TITLE
Improve VR environment error reporting

### DIFF
--- a/jp2_pc/Source/Lib/VR/README.md
+++ b/jp2_pc/Source/Lib/VR/README.md
@@ -14,6 +14,8 @@ development libraries are not present the build instead compiles a stub and the
 environment will not be rendered. The environment intensity and orientation can
 be adjusted at runtime via `Renderer::SetEnvironmentIntensity()` and
 `Renderer::SetEnvironmentRotation()` whenever the renderer is available.
+Shader compilation and program linking errors are now reported to the console
+to aid debugging when OpenGL is used.
 
 ### Controller Input
 `VR::GetControllerInput()` returns an `SInput` struct describing the state of any

--- a/jp2_pc/Source/Lib/VR/VR.cpp
+++ b/jp2_pc/Source/Lib/VR/VR.cpp
@@ -16,11 +16,14 @@ bool Initialize(const char *envCubemapFolder) {
   std::printf("VR Initialize stub\n");
 
 #ifdef ENABLE_OCULUS_QUEST_SUPPORT
+  bool ok = false;
   if (envCubemapFolder) {
-    Renderer::InitializeEnvironment(envCubemapFolder);
+    ok = Renderer::InitializeEnvironment(envCubemapFolder);
   } else {
-    Renderer::InitializeEnvironment("assets/env");
+    ok = Renderer::InitializeEnvironment("assets/env");
   }
+  if (!ok)
+    std::fprintf(stderr, "Failed to initialise environment renderer\n");
   Renderer::SetEnvironmentIntensity(1.0f);
 #endif
 


### PR DESCRIPTION
## Summary
- improve shader error handling in `EnvironmentModern.cpp`
- warn if the environment renderer fails to initialise
- document the new console error logs in VR README

## Testing
- `cmake -S jp2_pc -B build && cmake --build build` *(failed: Non-Windows builds are unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6841dfd699d0833192b717ac6b03d44e