### PR TITLE
Expose environment controls through VR interface

### DIFF
--- a/jp2_pc/Source/Lib/VR/README.md
+++ b/jp2_pc/Source/Lib/VR/README.md
@@ -11,9 +11,9 @@ The optional modern environment renderer (`ENABLE_MODERN_ENV_RENDER`) now loads
 a cubemap using OpenGL and draws it each frame. Pass the cubemap folder to
 `VR::Initialize()` when starting the application. If the required OpenGL
 development libraries are not present the build instead compiles a stub and the
-environment will not be rendered. The environment intensity and orientation can
-be adjusted at runtime via `Renderer::SetEnvironmentIntensity()` and
-`Renderer::SetEnvironmentRotation()` whenever the renderer is available.
+ environment will not be rendered. The environment intensity and orientation can
+ be adjusted at runtime via `VR::SetEnvironmentIntensity()` and
+ `VR::SetEnvironmentRotation()` whenever the renderer is available.
 Shader compilation and program linking errors are now reported to the console
 to aid debugging when OpenGL is used.
 

--- a/jp2_pc/Source/Lib/VR/VR.cpp
+++ b/jp2_pc/Source/Lib/VR/VR.cpp
@@ -59,6 +59,22 @@ void EndFrame() {
 #endif
 }
 
+void SetEnvironmentIntensity(float intensity) {
+#ifdef ENABLE_OCULUS_QUEST_SUPPORT
+  Renderer::SetEnvironmentIntensity(intensity);
+#else
+  (void)intensity;
+#endif
+}
+
+void SetEnvironmentRotation(const float rotation[16]) {
+#ifdef ENABLE_OCULUS_QUEST_SUPPORT
+  Renderer::SetEnvironmentRotation(rotation);
+#else
+  (void)rotation;
+#endif
+}
+
 SInput GetControllerInput() {
   SInput input{};
 #ifdef ENABLE_OCULUS_QUEST_SUPPORT

--- a/jp2_pc/Source/Lib/VR/VR.hpp
+++ b/jp2_pc/Source/Lib/VR/VR.hpp
@@ -14,10 +14,19 @@ namespace VR {
 
 // Provide the path to a cubemap folder when initialising so the modern
 // environment renderer can load the textures.
-bool Initialize(const char *envCubemapFolder = nullptr);
-void Shutdown();
-void BeginFrame();
-void EndFrame();
+    bool Initialize(const char *envCubemapFolder = nullptr);
+    void Shutdown();
+    void BeginFrame();
+    void EndFrame();
+
+// Adjust the environment brightness. Values above 1.0 brighten the cubemap
+// while values below 1.0 darken it. Has no effect when the modern renderer
+// is not available.
+void SetEnvironmentIntensity(float intensity);
+
+// Apply a rotation matrix to the environment cubemap. Rotation should be a
+// 4x4 column-major matrix. Does nothing on stub builds.
+void SetEnvironmentRotation(const float rotation[16]);
 
 // Retrieve input from VR controllers when available.
 SInput GetControllerInput();


### PR DESCRIPTION
## Summary
- extend `VR` API with functions to control environment intensity and rotation
- implement wrappers in `VR.cpp`
- document usage in VR README

## Testing
- `cmake -S jp2_pc -B build` *(fails: Non-Windows builds are unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6841e121e19c8331b0260ad4c386c85a