### PR TITLE
Extend VR initialization options

### DIFF
--- a/jp2_pc/Source/Lib/VR/README.md
+++ b/jp2_pc/Source/Lib/VR/README.md
@@ -8,11 +8,12 @@ To build for Android enable the `ENABLE_OCULUS_QUEST_SUPPORT` option and use an 
 
 ### Environment Renderer
 The optional modern environment renderer (`ENABLE_MODERN_ENV_RENDER`) now loads
-a cubemap using OpenGL and draws it each frame. Pass the cubemap folder to
-`VR::Initialize()` when starting the application. If the required OpenGL
+a cubemap using OpenGL and draws it each frame. Pass the cubemap folder and an
+optional intensity value to `VR::Initialize()` when starting the application.
+If the required OpenGL
 development libraries are not present the build instead compiles a stub and the
- environment will not be rendered. The environment intensity and orientation can
- be adjusted at runtime via `VR::SetEnvironmentIntensity()` and
+environment will not be rendered. The environment intensity and orientation can
+be adjusted at runtime via `VR::SetEnvironmentIntensity()` and
  `VR::SetEnvironmentRotation()` whenever the renderer is available.
 Shader compilation and program linking errors are now reported to the console
 to aid debugging when OpenGL is used.

--- a/jp2_pc/Source/Lib/VR/VR.cpp
+++ b/jp2_pc/Source/Lib/VR/VR.cpp
@@ -11,7 +11,7 @@
 
 namespace VR {
 
-bool Initialize(const char *envCubemapFolder) {
+bool Initialize(const char *envCubemapFolder, float envIntensity) {
   // Placeholder for Oculus Quest initialization
   std::printf("VR Initialize stub\n");
 
@@ -24,7 +24,7 @@ bool Initialize(const char *envCubemapFolder) {
   }
   if (!ok)
     std::fprintf(stderr, "Failed to initialise environment renderer\n");
-  Renderer::SetEnvironmentIntensity(1.0f);
+  Renderer::SetEnvironmentIntensity(envIntensity);
 #endif
 
   return true;

--- a/jp2_pc/Source/Lib/VR/VR.hpp
+++ b/jp2_pc/Source/Lib/VR/VR.hpp
@@ -14,7 +14,11 @@ namespace VR {
 
 // Provide the path to a cubemap folder when initialising so the modern
 // environment renderer can load the textures.
-    bool Initialize(const char *envCubemapFolder = nullptr);
+    // Optionally specify an initial cubemap folder and brightness when
+    // initialising the VR system. The intensity parameter is passed directly
+    // to the modern environment renderer when available.
+    bool Initialize(const char *envCubemapFolder = nullptr,
+                    float envIntensity = 1.0f);
     void Shutdown();
     void BeginFrame();
     void EndFrame();

--- a/jp2_pc/Source/Lib/VR/android/VR_Android.cpp
+++ b/jp2_pc/Source/Lib/VR/android/VR_Android.cpp
@@ -5,7 +5,7 @@
 
 namespace VR {
 
-bool Initialize() {
+bool Initialize(const char *, float) {
 #ifdef __ANDROID__
     __android_log_print(ANDROID_LOG_INFO, "Trespasser", "VR Android Initialize stub");
 #endif


### PR DESCRIPTION
## Summary
- allow specifying initial environment intensity in VR initialization
- adjust VR Android stub to match new interface
- document the intensity parameter

## Testing
- `cmake -S jp2_pc -B build` *(fails: Non-Windows builds are unsupported)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_6841e349f1848331ba1910195d9c04b7