### PR TITLE
Enhance SDL controller handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,16 @@ The renderer exposes basic controls for VR integration. Use
 Desktop builds optionally support modern game controllers via SDL2.
 Enable the feature with the `USE_SDL_CONTROLLER` CMake option. When
 enabled the System library links against SDL2 and `CInput` will query
-connected gamepads for movement and basic button actions.
+connected gamepads for movement and basic button actions. `VR::GetControllerInput`
+shares the same mappings so controllers behave consistently in VR.
+The default bindings are:
+
+- **A** &rarr; `Use`
+- **B** &rarr; `Stow`
+- **X** &rarr; `Grab`
+- **Y** &rarr; `Jump`
+- **Left Shoulder** &rarr; `Control`
+- **Right Shoulder** &rarr; `Shift`
 
 ## Building on Linux
 

--- a/jp2_pc/Source/Lib/VR/README.md
+++ b/jp2_pc/Source/Lib/VR/README.md
@@ -20,6 +20,16 @@ to aid debugging when OpenGL is used.
 
 ### Controller Input
 `VR::GetControllerInput()` returns an `SInput` struct describing the state of any
-connected VR controllers. The current implementation is a stub which will return
-zeroed values when no VR controller integration is available.
+connected VR controllers. When built with `USE_SDL_CONTROLLER` enabled the stub
+also queries standard gamepads via SDL and maps buttons to common commands:
+
+- **A** &rarr; `uCMD_USE`
+- **B** &rarr; `uCMD_STOW`
+- **X** &rarr; `uCMD_GRAB`
+- **Y** &rarr; `uCMD_JUMP`
+- **Left Shoulder** &rarr; `uCMD_CONTROL`
+- **Right Shoulder** &rarr; `uCMD_SHIFT`
+
+If controller support is unavailable the function simply returns a zeroed
+structure.
 

--- a/jp2_pc/Source/Lib/VR/VR.cpp
+++ b/jp2_pc/Source/Lib/VR/VR.cpp
@@ -93,14 +93,28 @@ SInput GetControllerInput() {
     SDL_GameController *ctrl = SDL_GameControllerOpen(i);
     if (!ctrl)
       continue;
+
     const Sint16 lx = SDL_GameControllerGetAxis(ctrl, SDL_CONTROLLER_AXIS_LEFTX);
     const Sint16 ly = SDL_GameControllerGetAxis(ctrl, SDL_CONTROLLER_AXIS_LEFTY);
     const Sint16 rx = SDL_GameControllerGetAxis(ctrl, SDL_CONTROLLER_AXIS_RIGHTX);
     const Sint16 ry = SDL_GameControllerGetAxis(ctrl, SDL_CONTROLLER_AXIS_RIGHTY);
+
     input.v2Move = CVector2<>(lx / 32767.0f, -ly / 32767.0f);
     input.v2Rotate = CVector2<>(rx / 32767.0f, -ry / 32767.0f);
+
     if (SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_A))
       input.u4ButtonState |= uCMD_USE;
+    if (SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_B))
+      input.u4ButtonState |= uCMD_STOW;
+    if (SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_X))
+      input.u4ButtonState |= uCMD_GRAB;
+    if (SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_Y))
+      input.u4ButtonState |= uCMD_JUMP;
+    if (SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_RIGHTSHOULDER))
+      input.u4ButtonState |= uCMD_SHIFT;
+    if (SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_LEFTSHOULDER))
+      input.u4ButtonState |= uCMD_CONTROL;
+
     SDL_GameControllerClose(ctrl);
     break;
   }


### PR DESCRIPTION
## Summary
- expand SDL button mapping in `VR::GetControllerInput`
- document mappings in the VR stub README
- note button bindings in main README

## Testing
- `cmake -S jp2_pc -B build -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres` *(fails: BUILDVER_MODE not defined)*
- `cmake --build build` *(not executed due to prior failure)*

------
https://chatgpt.com/codex/tasks/task_e_6841e74098ec8331a8adb216f76633ea