### PR TITLE
Update trespass CMake minimum version

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10) project(JPT_Android)
+cmake_minimum_required(VERSION 3.15) project(JPT_Android)
 
     option(
         ENABLE_OCULUS_QUEST_SUPPORT

--- a/jp2_pc/cmake/trespass/CMakeLists.txt
+++ b/jp2_pc/cmake/trespass/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(trespass)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
## Summary
- update trespass CMake project to require CMake 3.15
- align android build script with same version

## Testing
- `cmake -S jp2_pc -B build` *(fails: Non-Windows builds are unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6872be32cbf48331b7eee34c69443d7e