### PR TITLE
Fix header pragma in renderer

### DIFF
--- a/jp2_pc/Source/Lib/Renderer/EnvironmentModern.cpp
+++ b/jp2_pc/Source/Lib/Renderer/EnvironmentModern.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #ifdef ENABLE_OCULUS_QUEST_SUPPORT
 
 #include "EnvironmentModern.hpp"


### PR DESCRIPTION
## Summary
- remove an erroneous `#pragma once` from `EnvironmentModern.cpp`
- verify the directive is not present anywhere else

The project does not support building on this platform, so CMake configuration fails.

## Testing
- `grep -R "#pragma once" -n --include=*.cpp | wc -l`
- `cmake -S jp2_pc -B build && cmake --build build` *(fails: Non-Windows builds are unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6872bf4c3ea08331869aac1c302869d9