### PR TITLE
Fix CMake gblinc path

### DIFF
--- a/jp2_pc/cmake/ScreenRenderDWI/CMakeLists.txt
+++ b/jp2_pc/cmake/ScreenRenderDWI/CMakeLists.txt
@@ -1,104 +1,108 @@
 project(ScreenRenderDWI)
 
+# Determine path to the jp2_pc directory. This allows configuring the project
+# even when CMAKE_SOURCE_DIR does not point at jp2_pc directly.
+get_filename_component(JP2_PC_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
 list(APPEND ScreenRenderDWI_Inc
-    ${CMAKE_SOURCE_DIR}/Source/gblinc/AsmSupport.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawSubTriangle.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawTriangle.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBump.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/FastBumpEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBumpMath.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBumpTable.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/GouraudT.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/RenderCache.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/RenderCacheHelp.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/RenderCachePriv.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/ScanlineAsmMacros.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderAuxD3D.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderAuxD3DBatch.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderDWI.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/Walk.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/WalkEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/RenderCacheInterface.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/RenderCacheLRUItem.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/ColLookupT.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/Edge.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/IndexPerspectiveT.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/LineBumpMake.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/MapT.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/Scanline.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/TransparencyT.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc/AsmSupport.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawSubTriangle.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawTriangle.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBump.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/FastBumpEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBumpMath.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBumpTable.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/GouraudT.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/RenderCache.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/RenderCacheHelp.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/RenderCachePriv.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/ScanlineAsmMacros.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderAuxD3D.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderAuxD3DBatch.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderDWI.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/Walk.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/WalkEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/RenderCacheInterface.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/RenderCacheLRUItem.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/ColLookupT.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/Edge.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/IndexPerspectiveT.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/LineBumpMake.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/MapT.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/Scanline.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/TransparencyT.hpp
 )
 
 list(APPEND ScreenRenderDWI_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawSubTriangle.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawTriangle.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawTriangleEx.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBump.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBumpMath.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBumpTable.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/RenderCache.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/RenderCacheHelp.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/RenderCachePriv.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderAuxD3D.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderAuxD3DBatch.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderDWI.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawSubTriangleFlat.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawSubTriangle.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawTriangle.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawTriangleEx.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBump.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBumpMath.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/FastBumpTable.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/RenderCache.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/RenderCacheHelp.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/RenderCachePriv.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderAuxD3D.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderAuxD3DBatch.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/ScreenRenderDWI.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/DrawSubTriangleFlat.inl
 )
 
 list(APPEND ScreenRenderDWI_P5_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleAlpha.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleBumpEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleBumpTblEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleGourEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleTerrain.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleTerrainEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleTexEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleTexGourEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleWater.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/FastBumpEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/IndexPerspectiveTEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/ScanlineAsmMacros.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/WalkEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleAlpha.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleBumpEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleBumpTblEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleGourEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleTerrain.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleTerrainEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleTexEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleTexGourEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/DrawSubTriangleWater.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/FastBumpEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/IndexPerspectiveTEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/ScanlineAsmMacros.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P5/WalkEx.hpp
 )
 
 list(APPEND ScreenRenderDWI_P6_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleAlpha.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleBumpEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleBumpTblEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleGourEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleTerrain.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleTerrainEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleTexEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleTexGourEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleWater.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/FastBumpEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/IndexPerspectiveTEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/ScanlineAsmMacros.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/WalkEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleAlpha.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleBumpEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleBumpTblEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleGourEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleTerrain.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleTerrainEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleTexEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleTexGourEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/DrawSubTriangleWater.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/FastBumpEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/IndexPerspectiveTEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/ScanlineAsmMacros.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/WalkEx.hpp
 )
 
 list(APPEND ScreenRenderDWI_AMDK6_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleAlpha.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleBumpEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleBumpTblEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleGourEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleTerrain.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleTerrainEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleTexEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleTexGourEx.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleWater.inl
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/FastBumpEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/IndexPerspectiveTEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/ScanlineAsmMacros.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/WalkEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleAlpha.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleBumpEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleBumpTblEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleGourEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleTerrain.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleTerrainEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleTexEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleTexGourEx.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/DrawSubTriangleWater.inl
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/FastBumpEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/IndexPerspectiveTEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/ScanlineAsmMacros.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Renderer/Primitives/AMDK6/WalkEx.hpp
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/Source
-    ${CMAKE_SOURCE_DIR}/Source/gblinc
+    ${JP2_PC_SOURCE_DIR}/Source
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc
 )
 
 add_common_options()

--- a/jp2_pc/cmake/Std/CMakeLists.txt
+++ b/jp2_pc/cmake/Std/CMakeLists.txt
@@ -1,52 +1,55 @@
 project(Std)
 
+# Resolve jp2_pc directory for out-of-tree configuration.
+get_filename_component(JP2_PC_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
 list(APPEND Std_Inc
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Array.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Array2.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/ArrayAllocator.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/ArrayIO.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/BlockAllocator.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/BlockArray.hpp
-    ${CMAKE_SOURCE_DIR}/Source/gblinc/buildver.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/CircularList.hpp
-    ${CMAKE_SOURCE_DIR}/Source/gblinc/common.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/CRC.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Hash.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/InitSys.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/LocalArray.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Mem.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/MemLimits.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/PrivSelf.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Ptr.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Random.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/RangeVar.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Set.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Sort.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/SparseArray.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/StdLibEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/StringEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/TreeList.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/UAssert.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/UDefs.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/UTypes.hpp
-    ${CMAKE_SOURCE_DIR}/Source/gblinc/Warnings.hpp
-    ${CMAKE_SOURCE_DIR}/Source/gblinc/version.hpp
-    ${CMAKE_SOURCE_DIR}/Source/gblinc/VerBones.hpp
-    ${CMAKE_SOURCE_DIR}/Source/gblinc/3DX.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Array.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Array2.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/ArrayAllocator.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/ArrayIO.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/BlockAllocator.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/BlockArray.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc/buildver.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/CircularList.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc/common.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/CRC.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Hash.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/InitSys.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/LocalArray.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Mem.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/MemLimits.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/PrivSelf.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Ptr.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Random.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/RangeVar.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Set.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Sort.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/SparseArray.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/StdLibEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/StringEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/TreeList.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/UAssert.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/UDefs.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/UTypes.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc/Warnings.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc/version.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc/VerBones.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc/3DX.hpp
 )
 
 list(APPEND Std_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Hash.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/InitSys.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Mem.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Ptr.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/Random.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Std/StringEx.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Hash.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/InitSys.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Mem.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Ptr.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/Random.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Std/StringEx.cpp
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/Source
-    ${CMAKE_SOURCE_DIR}/Source/gblinc
+    ${JP2_PC_SOURCE_DIR}/Source
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc
 )
 
 add_common_options()

--- a/jp2_pc/cmake/System/CMakeLists.txt
+++ b/jp2_pc/cmake/System/CMakeLists.txt
@@ -1,80 +1,83 @@
 project(System)
 
+# Resolve jp2_pc directory for out-of-tree configuration.
+get_filename_component(JP2_PC_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
 list(APPEND System_Inc
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/BitBuffer.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/Com.hpp
-    ${CMAKE_SOURCE_DIR}/Source/gblinc/Config.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ConIO.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Control/Control.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/DebugConsole.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Errors.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ExePageModify.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/FastHeap.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/FileMapping.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/FixedHeap.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/LRU.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/MemoryLog.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/PerformanceCount.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ProcessorDetect.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Profile.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/reg.h
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/RegInit.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/W95/Render.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Scheduler.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/StdDialog.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ThreadControl.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/VirtualMem.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Shell/WinRenderTools.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/Errors.h
-    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/WinAlias.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/WinInclude.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Timer.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ThreadActionBase.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/FileEx.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Textout.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/P5/Msr.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/IniFile.hpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/RegToIni.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/BitBuffer.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/W95/Com.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc/Config.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/ConIO.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Control/Control.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/DebugConsole.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/Errors.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/ExePageModify.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/FastHeap.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/FileMapping.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/FixedHeap.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/LRU.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/MemoryLog.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/PerformanceCount.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/ProcessorDetect.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/Profile.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/reg.h
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/RegInit.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/W95/Render.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/Scheduler.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/StdDialog.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/ThreadControl.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/VirtualMem.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Shell/WinRenderTools.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/W95/Errors.h
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/W95/WinAlias.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/W95/WinInclude.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/Timer.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/ThreadActionBase.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/FileEx.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/Textout.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/P5/Msr.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/IniFile.hpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/RegToIni.hpp
 )
 
 list(APPEND System_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/BitBuffer.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/Com.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ConIO.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Control/Control.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/DebugConsole.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/W95/Errors.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/W95/ExePageModify.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/W95/FastHeap.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/W95/FileEx.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/FileMapping.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/FixedHeap.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/LRU.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/MemoryLog.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/PerformanceCount.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ProcessorDetect.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Profile.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/reg.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/RegInit.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/W95/Render.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Scheduler.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/StdDialog.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/W95/Textout.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ThreadControl.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/W95/Timer.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/VirtualMem.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Shell/WinRenderTools.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/IniFile.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/RegToIni.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/BitBuffer.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/W95/Com.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/ConIO.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Control/Control.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/DebugConsole.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/W95/Errors.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/W95/ExePageModify.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/W95/FastHeap.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/W95/FileEx.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/FileMapping.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/FixedHeap.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/LRU.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/MemoryLog.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/PerformanceCount.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/ProcessorDetect.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/Profile.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/reg.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/RegInit.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/W95/Render.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/Scheduler.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/StdDialog.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/W95/Textout.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/ThreadControl.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/W95/Timer.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/VirtualMem.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Shell/WinRenderTools.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/IniFile.cpp
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/Sys/RegToIni.cpp
 )
 
 list(APPEND System_Rsc
-    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/Errors.rc
+    ${JP2_PC_SOURCE_DIR}/Source/Lib/W95/Errors.rc
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/Source
-    ${CMAKE_SOURCE_DIR}/Source/gblinc
+    ${JP2_PC_SOURCE_DIR}/Source
+    ${JP2_PC_SOURCE_DIR}/Source/gblinc
 )
 
 add_common_options()


### PR DESCRIPTION
## Summary
- resolve jp2_pc root in ScreenRenderDWI, Std and System
- use that variable for source file paths

## Testing
- `cmake -S jp2_pc -B build` *(fails: Non-Windows builds are unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6872d1b836908331ab2dc769fa101411