### PR TITLE
Fix VR init return code

### DIFF
--- a/jp2_pc/Source/Lib/VR/README.md
+++ b/jp2_pc/Source/Lib/VR/README.md
@@ -10,6 +10,8 @@ To build for Android enable the `ENABLE_OCULUS_QUEST_SUPPORT` option and use an 
 The optional modern environment renderer (`ENABLE_MODERN_ENV_RENDER`) now loads
 a cubemap using OpenGL and draws it each frame. Pass the cubemap folder and an
 optional intensity value to `VR::Initialize()` when starting the application.
+`VR::Initialize()` returns **false** if the cubemap or shaders fail to load,
+allowing callers to detect when the renderer is unavailable.
 If the required OpenGL
 development libraries are not present the build instead compiles a stub and the
 environment will not be rendered. The environment intensity and orientation can

--- a/jp2_pc/Source/Lib/VR/VR.cpp
+++ b/jp2_pc/Source/Lib/VR/VR.cpp
@@ -25,9 +25,12 @@ bool Initialize(const char *envCubemapFolder, float envIntensity) {
   if (!ok)
     std::fprintf(stderr, "Failed to initialise environment renderer\n");
   Renderer::SetEnvironmentIntensity(envIntensity);
-#endif
-
+  return ok;
+#else
+  (void)envCubemapFolder;
+  (void)envIntensity;
   return true;
+#endif
 }
 
 void Shutdown() {

--- a/jp2_pc/Source/Lib/VR/VR.hpp
+++ b/jp2_pc/Source/Lib/VR/VR.hpp
@@ -17,6 +17,9 @@ namespace VR {
     // Optionally specify an initial cubemap folder and brightness when
     // initialising the VR system. The intensity parameter is passed directly
     // to the modern environment renderer when available.
+    // Returns true on success. When Quest support is enabled the value
+    // reflects whether the modern environment renderer initialised
+    // correctly.
     bool Initialize(const char *envCubemapFolder = nullptr,
                     float envIntensity = 1.0f);
     void Shutdown();


### PR DESCRIPTION
## Summary
- return VR environment renderer result when Quest support is enabled
- clarify Initialize behaviour in headers and documentation

## Testing
- `cmake -S jp2_pc -B build` *(fails: Non-Windows builds are unsupported)*
- `cmake --build build` *(fails: No rule to make target `Makefile`)*

------
https://chatgpt.com/codex/tasks/task_e_6872e84bb39c8331b99eb490d25a19ff