### PR TITLE
Fix VR source selection for Android

### DIFF
--- a/jp2_pc/cmake/VR/CMakeLists.txt
+++ b/jp2_pc/cmake/VR/CMakeLists.txt
@@ -4,13 +4,13 @@ list(APPEND VR_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/VR/VR.hpp
 )
 
-list(APPEND VR_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/VR/VR.cpp
-)
-
 if(ANDROID)
-    list(APPEND VR_Src
+    set(VR_Src
         ${CMAKE_SOURCE_DIR}/Source/Lib/VR/android/VR_Android.cpp
+    )
+else()
+    set(VR_Src
+        ${CMAKE_SOURCE_DIR}/Source/Lib/VR/VR.cpp
     )
 endif()
 


### PR DESCRIPTION
## Summary
- use platform-specific VR source in CMake

## Testing
- `cmake -S jp2_pc -B build -DCMAKE_SYSTEM_NAME=Windows`
- `cmake --build build` *(fails: `BUILDVER_MODE not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_6872f88fbcb08331ad0a52f3e5dea120