### PR TITLE
Fix header case and include order

### DIFF
--- a/jp2_pc/Source/Game/AI/Activity.cpp
+++ b/jp2_pc/Source/Game/AI/Activity.cpp
@@ -85,7 +85,7 @@
 #include "Lib/EntityDBase/Animal.hpp"
 
 #include "Lib/EntityDBase/MessageTypes/MsgAudio.hpp"
-#include "Lib/Audio/Sounddefs.hpp"
+#include "Lib/Audio/SoundDefs.hpp"
 #include "Lib/Audio/AudioLoader.hpp"
 
 #include "Lib/Loader/SaveFile.hpp"

--- a/jp2_pc/Source/Lib/Loader/SaveFile.hpp
+++ b/jp2_pc/Source/Lib/Loader/SaveFile.hpp
@@ -1,6 +1,6 @@
 /**********************************************************************************************
  *
- * Copyright © DreamWorks Interactive, 1996
+ * Copyright Â© DreamWorks Interactive, 1996
  *
  * Contents:
  *		Save class for Trespasser CInstances (could be a CSaveable at some point).
@@ -80,7 +80,7 @@
 //
 
 #include "SaveBuffer.hpp"
-#include "Lib/GROFF/FileIO.hpp"
+#include "Lib/Groff/FileIO.hpp"
 #include "Lib/Sys/Timer.hpp"
 #include <set>
 

--- a/jp2_pc/Source/gblinc/common.hpp
+++ b/jp2_pc/Source/gblinc/common.hpp
@@ -75,12 +75,12 @@
 
 #include "BuildVer.hpp"
 
+#include "Lib/Std/UDefs.hpp"
+#include "Lib/Std/UAssert.hpp"
 #include "Lib/Std/Array.hpp"
 #include "Lib/Std/InitSys.hpp"
 #include "Lib/Std/Ptr.hpp"
 #include "Lib/Std/StdLibEx.hpp"
-#include "Lib/Std/UAssert.hpp"
-#include "Lib/Std/UDefs.hpp"
 #include "Lib/Std/UTypes.hpp"
 
 #endif


### PR DESCRIPTION
## Summary
- fix case mismatch for SoundDefs include
- fix case mismatch for Groff include
- include UDefs and UAssert before other std headers

## Testing
- `cmake -S jp2_pc -B build -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_BUILD_TYPE=Release` *(fails: missing declarations and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877053180ac83319df9631084af9a74